### PR TITLE
[DeviantArt] Adding support for sub-folders

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -691,6 +691,10 @@ x2="45.4107524%" y2="71.4898596%" id="app-root-3">\
             for folder in folders:
                 if folder["folderid"] == uuid:
                     return folder
+                elif folder["has_subfolders"]:
+                    for subfolder in folder["subfolders"]:
+                        if subfolder["folderid"] == uuid:
+                            return subfolder
         raise exception.NotFoundError("folder")
 
     def _folder_urls(self, folders, category, extractor):
@@ -988,13 +992,39 @@ class DeviantartFolderExtractor(DeviantartExtractor):
     def deviations(self):
         folders = self.api.gallery_folders(self.user)
         folder = self._find_folder(folders, self.folder_name, self.folder_id)
+
+        # Leaving this here for backwards compatibility
         self.folder = {
             "title": folder["name"],
             "uuid" : folder["folderid"],
             "index": self.folder_id,
             "owner": self.user,
+            "parent_uuid": folder["parent"],
         }
-        return self.api.gallery(self.user, folder["folderid"], self.offset)
+
+        del folder["thumb"]
+
+        if folder.get('subfolder'):
+            self.folder["parent_folder"] = folder["parent_folder"]
+            self.archive_fmt = "F_{folder[parent_uuid]}_{index}.{extension}"
+
+            if self.flat:
+                self.directory_fmt = ("{category}", "{username}",
+                                      "{folder[parent_folder]}")
+            else:
+                self.directory_fmt = ("{category}", "{username}",
+                                      "{folder[parent_folder]}",
+                                      "{folder[title]}")
+
+        if folder['has_subfolders']:
+            for subfolder in folder["subfolders"]:
+                subfolder["parent_folder"] = folder["name"]
+                subfolder["subfolder"] = True
+
+            yield from self._folder_urls(folder['subfolders'],
+                                         "gallery", DeviantartFolderExtractor)
+
+        yield from self.api.gallery(self.user, folder["folderid"], self.offset)
 
     def prepare(self, deviation):
         DeviantartExtractor.prepare(self, deviation)
@@ -1376,7 +1406,7 @@ class DeviantartOAuthAPI():
     def __init__(self, extractor):
         self.extractor = extractor
         self.log = extractor.log
-        self.headers = {"dA-minor-version": "20200519"}
+        self.headers = {"dA-minor-version": "20210526"}
         self._warn_429 = True
 
         self.delay = extractor.config("wait-min", 0)


### PR DESCRIPTION
# Overview
Bumping the header version from `20200519` -> `20210526` which brings support for sub-folders in Gallery and Collections (allegedly). The Collections API doesn't *actually* expose sub-folders nor can I find an example of a collection folder.


> May 26th 2021
> Added new version 20210526
[/gallery/folders](https://www.deviantart.com/developers/http/v1/20240701/gallery_folders/f6104e0d969bbbdcf2154e4b221aa3a6) - Galleries now can display sub-folders
[/collections/folders](https://www.deviantart.com/developers/http/v1/20240701/collections_folders/35030a41b12db6c4edf6bf9b163e4327) - Collections now can display sub-folders


## Process
This will first iterate the `sub-folders` then proceed to do the main folder requested. I chose this path as it is not uncommon to have people put things in ***both*** the **main** and **sub-folder**. 

This logs into the archive by default with the ***parent*** folder uuid so that way the picture will be unique to a folder/sub-folder.

It flattens the folder structure by **default** just like the Gallery and Favorites using the 

## Questions
1. Do we want to add a config option to choose whether main folder vs sub-folders comes first? Or should we reverse the pattern currently?
2. Should there be a separate flag to flatten sub-folders (currently using the same `flat` option as the Gallery/Favorites).

Also a general question about how we want flatten to work - do we want to roll images up into the main folder or flatten the directory structure and move the sub-folders up to the main folders level?

```
> Deviant Art Folders
/MainFolder/SubFolder1/
/MainFolder/SubFolder2/

> Option A - Current Implementation
/MainFolder/<DEVIATIONS FROM MAIN AND SUB FOLDERS>

> Option B
/MainFolder/<DEVIATIONS>
/SubFolder1/<DEVIATIONS>
/SubFolder2/<DEVIATIONS>
```

## Tests
I am not sure how to setup a test currently for checking this (I'm still exploring that part of the repo). However here are two good examples for sub-folders (SFW)
> [Avapithecus](https://www.deviantart.com/avapithecus/gallery/71028779/drake-hero) - Some form of Hero Art
> [Bold Frontiers](https://www.deviantart.com/boldfrontiers/gallery/58825179/travel-canada) - Photography and been around for about 19 years

## Changes
1. Updated the `DeviantartFolderExtractor` to support sub-folders
2. Updated the `_find_folder` function to iterate over the sub-folders
3. Updated the header version to be `20210526`


Closes: #4988